### PR TITLE
Validation rules

### DIFF
--- a/lib/formalist.rb
+++ b/lib/formalist.rb
@@ -2,5 +2,6 @@ module Formalist
   DEFAULT_DISPLAY_ADAPTER = "default".freeze
 end
 
+require "dry-validation"
 require "formalist/form"
 require "formalist/output_compiler"

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -32,14 +32,9 @@ module Formalist
       @schema = schema
     end
 
-    def call(input, validate: true)
-      if validate && schema
-        rules = schema.rules.map(&:to_ary)
-        errors = schema.(input).messages
-      else
-        rules = []
-        errors = {}
-      end
+    def call(input = {}, validate: true)
+      rules = schema ? schema.rules.map(&:to_ary) : []
+      errors = validate && schema ? schema.(input).messages : {}
 
       Result.new(elements.map { |el| el.(input, rules, errors) })
     end

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -32,7 +32,9 @@ module Formalist
       @schema = schema
     end
 
-    def call(input = {}, validate: true)
+    def call(input = {}, options = {})
+      validate = options.fetch(:validate, true)
+
       rules = schema ? schema.rules.map(&:to_ary) : []
       errors = validate && schema ? schema.(input).messages : {}
 

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -33,9 +33,15 @@ module Formalist
     end
 
     def call(input, validate: true)
-      error_messages = validate && schema ? schema.(input).messages : {}
+      if validate && schema
+        rules = schema.rules.map(&:to_ary)
+        errors = schema.(input).messages
+      else
+        rules = []
+        errors = {}
+      end
 
-      Result.new(elements.map { |el| el.(input, error_messages) })
+      Result.new(elements.map { |el| el.(input, rules, errors) })
     end
   end
 end

--- a/lib/formalist/form/definition/attr.rb
+++ b/lib/formalist/form/definition/attr.rb
@@ -11,8 +11,8 @@ module Formalist
           @children = children
         end
 
-        def call(input, errors)
-          Result::Attr.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Attr.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/definition/component.rb
+++ b/lib/formalist/form/definition/component.rb
@@ -23,8 +23,8 @@ module Formalist
           self.class.new(config.merge(new_config), children)
         end
 
-        def call(input, errors)
-          Result::Component.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Component.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/definition/field.rb
+++ b/lib/formalist/form/definition/field.rb
@@ -34,8 +34,8 @@ module Formalist
           self.class.new(name, type, display_variant, config.merge(new_config))
         end
 
-        def call(input, errors)
-          Result::Field.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Field.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/definition/group.rb
+++ b/lib/formalist/form/definition/group.rb
@@ -22,8 +22,8 @@ module Formalist
           @children = children
         end
 
-        def call(input, errors)
-          Result::Group.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Group.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/definition/many.rb
+++ b/lib/formalist/form/definition/many.rb
@@ -32,8 +32,8 @@ module Formalist
           @children = children
         end
 
-        def call(input, errors)
-          Result::Many.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Many.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/definition/section.rb
+++ b/lib/formalist/form/definition/section.rb
@@ -14,8 +14,8 @@ module Formalist
           @children = children
         end
 
-        def call(input, errors)
-          Result::Section.new(self, input, errors)
+        def call(input, rules, errors)
+          Result::Section.new(self, input, rules, errors)
         end
       end
     end

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -1,3 +1,5 @@
+require "formalist/validation/targeted_rules_compiler"
+
 module Formalist
   class Form
     class Result
@@ -6,9 +8,11 @@ module Formalist
         attr_reader :children
 
         def initialize(definition, input, rules, errors)
+          rules_compiler = Validation::TargetedRulesCompiler.new(definition.name)
+
           @definition = definition
           @input = input.fetch(definition.name, {})
-          @rules = rules # TODO
+          @rules = rules_compiler.(rules)
           @errors = errors.fetch(definition.name, [])[0] || []
           @children = build_children
         end
@@ -20,15 +24,22 @@ module Formalist
           # Errors, if the attr hash hasn't been provided
           # {:meta=>[["meta is missing"], nil]}
 
+          local_rules = rules # TODO
           local_errors = errors[0].is_a?(Hash) ? [] : errors
-          [:attr, [definition.name, children.map(&:to_ary), local_errors]]
+
+          [:attr, [
+            definition.name,
+            local_rules,
+            local_errors,
+            children.map(&:to_ary),
+          ]]
         end
 
         private
 
         def build_children
           child_errors = errors[0].is_a?(Hash) ? errors[0] : {}
-          definition.children.map { |el| el.(input, child_errors) }
+          definition.children.map { |el| el.(input, rules, child_errors) }
         end
       end
     end

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -23,6 +23,36 @@ module Formalist
           @children = build_children
         end
 
+        # Converts the attribute into an array format for including in a
+        # form's abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:attr, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Attribute name
+        # 1. Validation rules (if any)
+        # 1. Validation error messages (if any)
+        # 1. Child form elements
+        #
+        # @example "metadata" attr
+        #   attr.to_ary # =>
+        #   # [:attr, [
+        #   #   :metadata,
+        #   #   [
+        #   #     [:predicate, [:hash?, []]],
+        #   #   ],
+        #   #   ["metadata is missing"],
+        #   #   [
+        #   #     ...child elements...
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the attribute as an array.
         def to_ary
           # Errors, if the attr hash is present and its members have errors:
           # {:meta=>[[{:pages=>[["pages is missing"], nil]}], {}]}

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -2,12 +2,13 @@ module Formalist
   class Form
     class Result
       class Attr
-        attr_reader :definition, :input, :errors
+        attr_reader :definition, :input, :rules, :errors
         attr_reader :children
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input.fetch(definition.name, {})
+          @rules = rules # TODO
           @errors = errors.fetch(definition.name, [])[0] || []
           @children = build_children
         end

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -1,4 +1,5 @@
-require "formalist/validation/targeted_rules_compiler"
+require "formalist/validation/value_rules_compiler"
+
 
 module Formalist
   class Form
@@ -8,7 +9,7 @@ module Formalist
         attr_reader :children
 
         def initialize(definition, input, rules, errors)
-          rules_compiler = Validation::TargetedRulesCompiler.new(definition.name)
+          rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
 
           @definition = definition
           @input = input.fetch(definition.name, {})

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -1,19 +1,24 @@
+require "formalist/validation/collection_rules_compiler"
 require "formalist/validation/value_rules_compiler"
-
+require "formalist/validation/predicate_list_compiler"
 
 module Formalist
   class Form
     class Result
       class Attr
-        attr_reader :definition, :input, :rules, :errors
+        attr_reader :definition, :input, :value_rules, :value_predicates, :collection_rules, :errors
         attr_reader :children
 
         def initialize(definition, input, rules, errors)
-          rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
+          value_rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
+          value_predicates_compiler = Validation::PredicateListCompiler.new
+          collection_rules_compiler = Validation::CollectionRulesCompiler.new(definition.name)
 
           @definition = definition
           @input = input.fetch(definition.name, {})
-          @rules = rules_compiler.(rules)
+          @value_rules = value_rules_compiler.(rules)
+          @value_predicates = value_predicates_compiler.(@value_rules)
+          @collection_rules = collection_rules_compiler.(rules)
           @errors = errors.fetch(definition.name, [])[0] || []
           @children = build_children
         end
@@ -25,12 +30,11 @@ module Formalist
           # Errors, if the attr hash hasn't been provided
           # {:meta=>[["meta is missing"], nil]}
 
-          local_rules = rules # TODO
           local_errors = errors[0].is_a?(Hash) ? [] : errors
 
           [:attr, [
             definition.name,
-            local_rules,
+            value_predicates,
             local_errors,
             children.map(&:to_ary),
           ]]
@@ -40,7 +44,7 @@ module Formalist
 
         def build_children
           child_errors = errors[0].is_a?(Hash) ? errors[0] : {}
-          definition.children.map { |el| el.(input, rules, child_errors) }
+          definition.children.map { |el| el.(input, collection_rules, child_errors) }
         end
       end
     end

--- a/lib/formalist/form/result/component.rb
+++ b/lib/formalist/form/result/component.rb
@@ -13,6 +13,32 @@ module Formalist
           @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
+        # Converts the component into an array format for including in a
+        # form's abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:component, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Component configuration
+        # 1. Child form elements
+        #
+        # @example
+        #   component.to_ary # =>
+        #   # [:component, [
+        #   #   [
+        #   #     [:some_config_name, :some_config_value]
+        #   #   ],
+        #   #   [
+        #   #     ...child elements...
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the component as an array.
         def to_ary
           [:component, [
             definition.config.to_a,

--- a/lib/formalist/form/result/component.rb
+++ b/lib/formalist/form/result/component.rb
@@ -2,12 +2,13 @@ module Formalist
   class Form
     class Result
       class Component
-        attr_reader :definition, :input, :errors
+        attr_reader :definition, :input, :rules, :errors
         attr_reader :children
 
         def initialize(definition, input, errors)
           @definition = definition
           @input = input
+          @rules = rules # TODO
           @errors = errors
           @children = definition.children.map { |el| el.(input, errors) }
         end

--- a/lib/formalist/form/result/component.rb
+++ b/lib/formalist/form/result/component.rb
@@ -5,16 +5,19 @@ module Formalist
         attr_reader :definition, :input, :rules, :errors
         attr_reader :children
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input
-          @rules = rules # TODO
+          @rules = rules
           @errors = errors
-          @children = definition.children.map { |el| el.(input, errors) }
+          @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
         def to_ary
-          [:component, [children.map(&:to_ary), definition.config.to_a]]
+          [:component, [
+            definition.config.to_a,
+            children.map(&:to_ary),
+          ]]
         end
       end
     end

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -2,11 +2,12 @@ module Formalist
   class Form
     class Result
       class Field
-        attr_reader :definition, :input, :errors
+        attr_reader :definition, :input, :rules, :errors
 
         def initialize(definition, input, errors)
           @definition = definition
           @input = input[definition.name]
+          @rules = rules # TODO
           @errors = errors[definition.name].to_a[0] || []
         end
 

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -18,6 +18,45 @@ module Formalist
           @errors = errors[definition.name].to_a[0] || []
         end
 
+        # Converts the field into an array format for including in a form's
+        # abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:field, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Field name
+        # 1. Field type
+        # 1. Display variant name
+        # 1. Input data
+        # 1. Validation rules (if any)
+        # 1. Validation error messages (if any)
+        # 1. Field configuration
+        #
+        # @example "email" field
+        #   field.to_ary # =>
+        #   # [:field, [
+        #   #   :email,
+        #   #   "string",
+        #   #   "default",
+        #   #   "invalid email value",
+        #   #   [
+        #   #     [:and, [
+        #   #       [:predicate, [:filled?, []]],
+        #   #       [:predicate, [:format?, [/\s+@\s+\.\s+/]]]
+        #   #     ]]
+        #   #   ],
+        #   #   ["email is in invalid format"],
+        #   #   [
+        #   #     [:some_config_name, :some_config_value]
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the field as an array.
         def to_ary
           # errors looks like this
           # {:field_name => [["pages is missing", "another error message"], nil]}

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -1,4 +1,4 @@
-require "formalist/validation/targeted_rules_compiler"
+require "formalist/validation/value_rules_compiler"
 
 module Formalist
   class Form
@@ -7,7 +7,7 @@ module Formalist
         attr_reader :definition, :input, :rules, :errors
 
         def initialize(definition, input, rules, errors)
-          rules_compiler = Validation::TargetedRulesCompiler.new(definition.name)
+          rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
 
           @definition = definition
           @input = input[definition.name]

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -1,17 +1,20 @@
 require "formalist/validation/value_rules_compiler"
+require "formalist/validation/predicate_list_compiler"
 
 module Formalist
   class Form
     class Result
       class Field
-        attr_reader :definition, :input, :rules, :errors
+        attr_reader :definition, :input, :rules, :predicates, :errors
 
         def initialize(definition, input, rules, errors)
           rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
+          predicates_compiler = Validation::PredicateListCompiler.new
 
           @definition = definition
           @input = input[definition.name]
           @rules = rules_compiler.(rules)
+          @predicates = predicates_compiler.(@rules)
           @errors = errors[definition.name].to_a[0] || []
         end
 
@@ -24,7 +27,7 @@ module Formalist
             definition.type,
             definition.display_variant,
             Dry::Data[definition.type].(input),
-            rules,
+            predicates,
             errors,
             definition.config.to_a,
           ]]

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -1,13 +1,17 @@
+require "formalist/validation/targeted_rules_compiler"
+
 module Formalist
   class Form
     class Result
       class Field
         attr_reader :definition, :input, :rules, :errors
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
+          rules_compiler = Validation::TargetedRulesCompiler.new(definition.name)
+
           @definition = definition
           @input = input[definition.name]
-          @rules = rules # TODO
+          @rules = rules_compiler.(rules)
           @errors = errors[definition.name].to_a[0] || []
         end
 
@@ -20,9 +24,10 @@ module Formalist
             definition.type,
             definition.display_variant,
             Dry::Data[definition.type].(input),
+            rules,
             errors,
-            definition.config.to_a]
-          ]
+            definition.config.to_a,
+          ]]
         end
       end
     end

--- a/lib/formalist/form/result/group.rb
+++ b/lib/formalist/form/result/group.rb
@@ -13,6 +13,32 @@ module Formalist
           @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
+        # Converts the group into an array format for including in a form's
+        # abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:group, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Group configuration
+        # 1. Child form elements
+        #
+        # @example
+        #   group.to_ary # =>
+        #   # [:group, [
+        #   #   [
+        #   #     [:some_config_name, :some_config_value]
+        #   #   ],
+        #   #   [
+        #   #     ...child elements...
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the group as an array.
         def to_ary
           [:group, [
             definition.config.to_a,

--- a/lib/formalist/form/result/group.rb
+++ b/lib/formalist/form/result/group.rb
@@ -5,9 +5,10 @@ module Formalist
         attr_reader :definition, :input, :errors
         attr_reader :children
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input
+          @rules = rules # TODO
           @errors = errors
           @children = definition.children.map { |el| el.(input, errors) }
         end

--- a/lib/formalist/form/result/group.rb
+++ b/lib/formalist/form/result/group.rb
@@ -8,13 +8,16 @@ module Formalist
         def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input
-          @rules = rules # TODO
+          @rules = rules
           @errors = errors
-          @children = definition.children.map { |el| el.(input, errors) }
+          @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
         def to_ary
-          [:group, [children.map(&:to_ary), definition.config.to_a]]
+          [:group, [
+            definition.config.to_a,
+            children.map(&:to_ary),
+          ]]
         end
       end
     end

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -1,20 +1,24 @@
 require "formalist/validation/collection_rules_compiler"
 require "formalist/validation/value_rules_compiler"
+require "formalist/validation/predicate_list_compiler"
+
 
 module Formalist
   class Form
     class Result
       class Many
-        attr_reader :definition, :input, :value_rules, :collection_rules, :errors
+        attr_reader :definition, :input, :value_rules, :value_predicates, :collection_rules, :errors
         attr_reader :child_template, :children
 
         def initialize(definition, input, rules, errors)
           value_rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
+          value_predicates_compiler = Validation::PredicateListCompiler.new
           collection_rules_compiler = Validation::CollectionRulesCompiler.new(definition.name)
 
           @definition = definition
           @input = input.fetch(definition.name, [])
           @value_rules = value_rules_compiler.(rules)
+          @value_predicates = value_predicates_compiler.(@value_rules)
           @collection_rules = collection_rules_compiler.(rules)
           @errors = errors.fetch(definition.name, [])[0] || []
           @child_template = build_child_template
@@ -26,7 +30,7 @@ module Formalist
 
           [:many, [
             definition.name,
-            value_rules,
+            value_predicates,
             local_errors,
             definition.config.to_a,
             child_template.map(&:to_ary),

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -2,7 +2,6 @@ require "formalist/validation/collection_rules_compiler"
 require "formalist/validation/value_rules_compiler"
 require "formalist/validation/predicate_list_compiler"
 
-
 module Formalist
   class Form
     class Result
@@ -25,6 +24,55 @@ module Formalist
           @children = build_children
         end
 
+        # Converts a collection of "many" repeating elements into an array
+        # format for including in a form's abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:many, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Collection array name
+        # 1. Collection validation rules (if any)
+        # 1. Collection error messages (if any)
+        # 1. Collection configuration
+        # 1. Child element "template" (i.e. the form elements comprising a
+        #    single entry in the collection of "many" elements, without any
+        #    user data associated)
+        # 1. Child elements, one for each of the entries in the input data (or
+        #    none, if there is no or empty input data)
+        #
+        # @example "locations" collection
+        #   many.to_ary # =>
+        #   # [:many, [
+        #   #   :locations,
+        #   #   [[:predicate, [:min_size?, [3]]]],
+        #   #   ["locations size cannot be less than 3"],
+        #   #   [
+        #   #     [:allow_create, true],
+        #   #     [:allow_update, true],
+        #   #     [:allow_destroy, true],
+        #   #     [:allow_reorder, true]
+        #   #   ],
+        #   #   [
+        #   #     [:field, [:name, "string", "default", nil, [], [], []]],
+        #   #     [:field, [:address, "string", "default", nil, [], [], []]]
+        #   #   [
+        #   #     [
+        #   #       [:field, [:name, "string", "default", "Icelab Canberra", [], [], []]],
+        #   #       [:field, [:address, "string", "default", "Canberra, ACT, Australia", [], [], []]]
+        #   #     ],
+        #   #     [
+        #   #       [:field, [:name, "string", "default", "Icelab Melbourne", [], [], []]],
+        #   #       [:field, [:address, "string", "default", "Melbourne, VIC, Australia", [], [], []]]
+        #   #     ]
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the collection as an array.
         def to_ary
           local_errors = errors[0].is_a?(String) ? errors : []
 

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -1,30 +1,32 @@
-require "formalist/validation/targeted_rules_compiler"
+require "formalist/validation/collection_rules_compiler"
+require "formalist/validation/value_rules_compiler"
 
 module Formalist
   class Form
     class Result
       class Many
-        attr_reader :definition, :input, :rules, :errors
+        attr_reader :definition, :input, :value_rules, :collection_rules, :errors
         attr_reader :child_template, :children
 
         def initialize(definition, input, rules, errors)
-          rules_compiler = Validation::TargetedRulesCompiler.new(definition.name)
+          value_rules_compiler = Validation::ValueRulesCompiler.new(definition.name)
+          collection_rules_compiler = Validation::CollectionRulesCompiler.new(definition.name)
 
           @definition = definition
           @input = input.fetch(definition.name, [])
-          @rules = rules_compiler.(rules)
+          @value_rules = value_rules_compiler.(rules)
+          @collection_rules = collection_rules_compiler.(rules)
           @errors = errors.fetch(definition.name, [])[0] || []
           @child_template = build_child_template
           @children = build_children
         end
 
         def to_ary
-          local_rules = rules # TODO: how do I extract rules _directly_ applying to the many's container element?
           local_errors = errors[0].is_a?(String) ? errors : []
 
           [:many, [
             definition.name,
-            local_rules,
+            value_rules,
             local_errors,
             definition.config.to_a,
             child_template.map(&:to_ary),
@@ -38,7 +40,7 @@ module Formalist
           template_input = {}
           template_errors = {}
 
-          definition.children.map { |el| el.(template_input, rules, template_errors)}
+          definition.children.map { |el| el.(template_input, collection_rules, template_errors)}
         end
 
         def build_children
@@ -58,7 +60,7 @@ module Formalist
           input.map { |child_input|
             local_child_errors = child_errors.map { |error| error[definition.name] }.detect { |error| error[1] == child_input }.to_a.dig(0, 0) || {}
 
-            definition.children.map { |el| el.(child_input, rules, local_child_errors) }
+            definition.children.map { |el| el.(child_input, collection_rules, local_child_errors) }
           }
         end
       end

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -74,7 +74,7 @@ module Formalist
         #
         # @return [Array] the collection as an array.
         def to_ary
-          local_errors = errors[0].is_a?(String) ? errors : []
+          local_errors = errors.select { |e| e.is_a?(String) }
 
           [:many, [
             definition.name,
@@ -110,7 +110,13 @@ module Formalist
           child_errors = errors[0].is_a?(Hash) ? errors : {}
 
           input.map { |child_input|
-            local_child_errors = child_errors.map { |error| error[definition.name] }.detect { |error| error[1] == child_input }.to_a.dig(0, 0) || {}
+            local_child_errors = child_errors.select { |e|
+              e.is_a?(Hash)
+            }.map { |e|
+              e[definition.name]
+            }.detect { |e|
+              e[1] == child_input
+            }.to_a.dig(0, 0) || {}
 
             definition.children.map { |el| el.(child_input, collection_rules, local_child_errors) }
           }

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -5,9 +5,10 @@ module Formalist
         attr_reader :definition, :input, :errors
         attr_reader :children
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input.fetch(definition.name, [])
+          @rules = rules # TODO
           @errors = errors.fetch(definition.name, [])[0] || []
           @children = build_children
         end

--- a/lib/formalist/form/result/section.rb
+++ b/lib/formalist/form/result/section.rb
@@ -13,6 +13,34 @@ module Formalist
           @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
+        # Converts the section into an array format for including in a form's
+        # abstract syntax tree.
+        #
+        # The array takes the following format:
+        #
+        # ```
+        # [:section, [params]]
+        # ```
+        #
+        # With the following parameters:
+        #
+        # 1. Section name
+        # 1. Section configuration
+        # 1. Child form elements
+        #
+        # @example "content" section
+        #   section.to_ary # =>
+        #   # [:section, [
+        #   #   :content,
+        #   #   [
+        #   #     [:some_config_name, :some_config_value]
+        #   #   ],
+        #   #   [
+        #   #     ...child elements...
+        #   #   ]
+        #   # ]]
+        #
+        # @return [Array] the section as an array.
         def to_ary
           [:section, [
             definition.name,

--- a/lib/formalist/form/result/section.rb
+++ b/lib/formalist/form/result/section.rb
@@ -2,12 +2,13 @@ module Formalist
   class Form
     class Result
       class Section
-        attr_reader :definition, :input, :errors
+        attr_reader :definition, :input, :rules, :errors
         attr_reader :children
 
-        def initialize(definition, input, errors)
+        def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input
+          @rules = rules # TODO
           @errors = errors
           @children = definition.children.map { |el| el.(input, errors) }
         end

--- a/lib/formalist/form/result/section.rb
+++ b/lib/formalist/form/result/section.rb
@@ -8,13 +8,17 @@ module Formalist
         def initialize(definition, input, rules, errors)
           @definition = definition
           @input = input
-          @rules = rules # TODO
+          @rules = rules
           @errors = errors
-          @children = definition.children.map { |el| el.(input, errors) }
+          @children = definition.children.map { |el| el.(input, rules, errors) }
         end
 
         def to_ary
-          [:section, [definition.name, children.map(&:to_ary), definition.config.to_a]]
+          [:section, [
+            definition.name,
+            definition.config.to_a,
+            children.map(&:to_ary),
+          ]]
         end
       end
     end

--- a/lib/formalist/output_compiler.rb
+++ b/lib/formalist/output_compiler.rb
@@ -23,33 +23,33 @@ module Formalist
     end
 
     def visit_attr(data)
-      name, elements, _errors = data
+      name, predicates, errors, children = data
 
-      {name => elements.map { |node| visit(node) }.inject(:merge) }
+      {name => children.map { |node| visit(node) }.inject(:merge) }
     end
 
     def visit_field(data)
-      name, type, display_variant, value, _errors = data
+      name, type, display_variant, value, predicates, errors = data
 
       {name => coerce(value, type: type)}
     end
 
     def visit_group(data)
-      elements, _config = data
+      config, children = data
 
-      elements.map { |node| visit(node) }.inject(:merge)
+      children.map { |node| visit(node) }.inject(:merge)
     end
 
     def visit_many(data)
-      name, elements, _errors, _config = data
+      name, predicates, errors, config, template, children = data
 
-      {name => elements.map { |item| item.map { |node| visit(node) }.inject(:merge) }}
+      {name => children.map { |item| item.map { |node| visit(node) }.inject(:merge) }}
     end
 
     def visit_section(data)
-      _name, elements, _config = data
+      name, config, children = data
 
-      elements.map { |node| visit(node) }.inject(:merge)
+      children.map { |node| visit(node) }.inject(:merge)
     end
 
     private

--- a/lib/formalist/validation/collection_rules_compiler.rb
+++ b/lib/formalist/validation/collection_rules_compiler.rb
@@ -1,16 +1,16 @@
 module Formalist
   module Validation
-    class TargetedRulesCompiler
+    class CollectionRulesCompiler
       IGNORED_PREDICATES = [:key?].freeze
 
-      attr_reader :field_name
+      attr_reader :target_name
 
-      def initialize(field_name)
-        @field_name = field_name
+      def initialize(target_name)
+        @target_name = target_name
       end
 
       def call(ast)
-        ast.map { |node| visit(node) }.reduce(:concat).each_slice(2).to_a
+        ast.map { |node| visit(node) }.reduce([], :concat).each_slice(2).to_a
       end
 
       private
@@ -20,38 +20,26 @@ module Formalist
         send(:"visit_#{name}", nodes)
       end
 
-      def visit_key(node)
-        # We can ignore "key" checks - we'll only pick up rules for keys we
-        # know will exist, since they're attached to fields.
-        []
-      end
-
-      def visit_val(node)
-        name, predicate = node
-        return [] unless name == field_name
-
-        visit(predicate)
-      end
-
       def visit_set(node)
         name, rules = node
-        return [] unless name == field_name
+        return [] unless name == target_name
 
         rules.flatten(1)
       end
 
       def visit_each(node)
         name, rule = node
-        return [] unless name == field_name
+        return [] unless name == target_name
 
         visit(rule)
       end
 
+      # I wonder if I need this here....
       def visit_predicate(node)
         name, args = node
         return [] if IGNORED_PREDICATES.include?(name)
 
-        node
+        [:predicate, node]
       end
 
       def visit_and(node)

--- a/lib/formalist/validation/collection_rules_compiler.rb
+++ b/lib/formalist/validation/collection_rules_compiler.rb
@@ -1,8 +1,6 @@
 module Formalist
   module Validation
     class CollectionRulesCompiler
-      IGNORED_PREDICATES = [:key?].freeze
-
       attr_reader :target_name
 
       def initialize(target_name)
@@ -34,11 +32,8 @@ module Formalist
         visit(rule)
       end
 
-      # I wonder if I need this here....
       def visit_predicate(node)
         name, args = node
-        return [] if IGNORED_PREDICATES.include?(name)
-
         [:predicate, node]
       end
 

--- a/lib/formalist/validation/field_rules_compiler.rb
+++ b/lib/formalist/validation/field_rules_compiler.rb
@@ -1,0 +1,53 @@
+module Formalist
+  module Validation
+    class FieldRulesCompiler
+      IGNORED_PREDICATES = [:key?].freeze
+
+      attr_reader :field_name
+
+      def initialize(field_name)
+        @field_name = field_name
+      end
+
+      def call(ast)
+        ast.map { |node| visit(node) }.reduce(:concat).each_slice(2).to_a
+      end
+
+      private
+
+      def visit(node)
+        name, nodes = node
+        send(:"visit_#{name}", nodes)
+      end
+
+      def visit_key(node)
+        # We can ignore "key" checks - we'll only pick up rules for keys we
+        # know will exist, since they're attached to fields.
+        []
+      end
+
+      def visit_val(node)
+        name, predicate = node
+        return [] unless name == field_name
+
+        visit(predicate)
+      end
+
+      def visit_predicate(node)
+        name, args = node
+        return [] if IGNORED_PREDICATES.include?(name)
+
+        node
+      end
+
+      def visit_and(node)
+        left, right = node
+        [visit(left), visit(right)].flatten(1)
+      end
+
+      def method_missing(name, *args)
+        []
+      end
+    end
+  end
+end

--- a/lib/formalist/validation/predicate_list_compiler.rb
+++ b/lib/formalist/validation/predicate_list_compiler.rb
@@ -1,0 +1,73 @@
+module Formalist
+  module Validation
+    class PredicateListCompiler
+      IGNORED_PREDICATES = [:key?].freeze
+
+      def call(ast)
+        ast.map { |node| visit(node) }.reduce([], :concat).each_slice(2).to_a
+      end
+
+      private
+
+      def visit(node)
+        name, nodes = node
+        send(:"visit_#{name}", nodes)
+      end
+
+      def visit_key(node)
+        name, predicate = node
+
+        visit(predicate)
+      end
+
+      def visit_val(node)
+        name, predicate = node
+
+        visit(predicate)
+      end
+
+      def visit_predicate(node)
+        name, args = node
+        return [] if IGNORED_PREDICATES.include?(name)
+
+        [:predicate, node]
+      end
+
+      def visit_and(node)
+        left, right = node
+        flatten_logical_operation(:and, [visit(left), visit(right)])
+      end
+
+      def visit_or(node)
+        left, right = node
+        flatten_logical_operation(:or, [visit(left), visit(right)])
+      end
+
+      def visit_xor(node)
+        left, right = node
+        flatten_logical_operation(:xor, [visit(left), visit(right)])
+      end
+
+      def visit_implication(node)
+        left, right = node
+        flatten_logical_operation(:implication, [visit(left), visit(right)])
+      end
+
+      def method_missing(name, *args)
+        []
+      end
+
+      def flatten_logical_operation(name, contents)
+        contents = contents.select(&:any?)
+
+        if contents.length == 0
+          []
+        elsif contents.length == 1
+          contents.first
+        else
+          [name, contents]
+        end
+      end
+    end
+  end
+end

--- a/lib/formalist/validation/targeted_rules_compiler.rb
+++ b/lib/formalist/validation/targeted_rules_compiler.rb
@@ -1,6 +1,6 @@
 module Formalist
   module Validation
-    class FieldRulesCompiler
+    class TargetedRulesCompiler
       IGNORED_PREDICATES = [:key?].freeze
 
       attr_reader :field_name
@@ -31,6 +31,20 @@ module Formalist
         return [] unless name == field_name
 
         visit(predicate)
+      end
+
+      def visit_set(node)
+        name, rules = node
+        return [] unless name == field_name
+
+        rules.flatten(1)
+      end
+
+      def visit_each(node)
+        name, rule = node
+        return [] unless name == field_name
+
+        visit(rule)
       end
 
       def visit_predicate(node)

--- a/lib/formalist/validation/targeted_rules_compiler.rb
+++ b/lib/formalist/validation/targeted_rules_compiler.rb
@@ -56,11 +56,38 @@ module Formalist
 
       def visit_and(node)
         left, right = node
-        [visit(left), visit(right)].flatten(1)
+        flatten_logical_operation(:and, [visit(left), visit(right)])
+      end
+
+      def visit_or(node)
+        left, right = node
+        flatten_logical_operation(:or, [visit(left), visit(right)])
+      end
+
+      def visit_xor(node)
+        left, right = node
+        flatten_logical_operation(:xor, [visit(left), visit(right)])
+      end
+
+      def visit_implication(node)
+        left, right = node
+        flatten_logical_operation(:implication, [visit(left), visit(right)])
       end
 
       def method_missing(name, *args)
         []
+      end
+
+      def flatten_logical_operation(name, contents)
+        contents = contents.select(&:any?)
+
+        if contents.length == 0
+          []
+        elsif contents.length == 1
+          contents.first
+        else
+          [name, contents]
+        end
       end
     end
   end

--- a/lib/formalist/validation/value_rules_compiler.rb
+++ b/lib/formalist/validation/value_rules_compiler.rb
@@ -1,0 +1,96 @@
+module Formalist
+  module Validation
+    class ValueRulesCompiler
+      IGNORED_PREDICATES = [:key?].freeze
+
+      attr_reader :target_name
+
+      def initialize(target_name)
+        @target_name = target_name
+      end
+
+      def call(ast)
+        ast.map { |node| visit(node) }.reduce([], :concat).each_slice(2).to_a
+      end
+
+      private
+
+      def visit(node)
+        name, nodes = node
+        send(:"visit_#{name}", nodes)
+      end
+
+      def visit_key(node)
+        # We can ignore "key" checks - we'll only pick up rules for keys we
+        # know will exist, since they're attached to fields.
+        []
+      end
+
+      def visit_val(node)
+        name, predicate = node
+        return [] unless name == target_name
+
+        # Skip the "val" prefix
+
+        [:val, [name, visit(predicate)]]
+      end
+
+      # def visit_set(node)
+      #   name, rules = node
+      #   return [] unless name == target_name
+
+      #   rules.flatten(1)
+      # end
+
+      # def visit_each(node)
+      #   name, rule = node
+      #   return [] unless name == target_name
+
+      #   visit(rule)
+      # end
+
+      def visit_predicate(node)
+        name, args = node
+        return [] if IGNORED_PREDICATES.include?(name)
+
+        [:predicate, node]
+      end
+
+      def visit_and(node)
+        left, right = node
+        flatten_logical_operation(:and, [visit(left), visit(right)])
+      end
+
+      def visit_or(node)
+        left, right = node
+        flatten_logical_operation(:or, [visit(left), visit(right)])
+      end
+
+      def visit_xor(node)
+        left, right = node
+        flatten_logical_operation(:xor, [visit(left), visit(right)])
+      end
+
+      def visit_implication(node)
+        left, right = node
+        flatten_logical_operation(:implication, [visit(left), visit(right)])
+      end
+
+      def method_missing(name, *args)
+        []
+      end
+
+      def flatten_logical_operation(name, contents)
+        contents = contents.select(&:any?)
+
+        if contents.length == 0
+          []
+        elsif contents.length == 1
+          contents.first
+        else
+          [name, contents]
+        end
+      end
+    end
+  end
+end

--- a/lib/formalist/validation/value_rules_compiler.rb
+++ b/lib/formalist/validation/value_rules_compiler.rb
@@ -1,8 +1,6 @@
 module Formalist
   module Validation
     class ValueRulesCompiler
-      IGNORED_PREDICATES = [:key?].freeze
-
       attr_reader :target_name
 
       def initialize(target_name)
@@ -51,8 +49,6 @@ module Formalist
 
       def visit_predicate(node)
         name, args = node
-        return [] if IGNORED_PREDICATES.include?(name)
-
         [:predicate, node]
       end
 

--- a/spec/integration/display_adapters_spec.rb
+++ b/spec/integration/display_adapters_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Display adapters" do
         "select",
         nil,
         [],
+        [],
         [
           [:option_values, [["c", "c"], ["f", "f"]]]
         ]
@@ -41,8 +42,8 @@ RSpec.describe "Display adapters" do
     end.new
 
     expect(form.({}).to_ary).to eq [
-      [:field, [:name, "string", "custom", nil, [], []]],
-      [:field, [:email, "string", "default", nil, [], []]],
+      [:field, [:name, "string", "custom", nil, [], [], []]],
+      [:field, [:email, "string", "default", nil, [], [], []]],
     ]
   end
 end

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe Formalist::Form do
   it "outputs an AST" do
     expect(form.(title: "Aurora", rating:  10).to_ary).to eq [
       [:component, [
+        [],
         [
-          [:field, [:title, "string", "default", "Aurora", [], []]],
-          [:field, [:rating, "int", "default", 10, [], []]]
+          [:field, [:title, "string", "default", "Aurora", [], [], []]],
+          [:field, [:rating, "int", "default", 10, [], [], []]]
         ],
-        []
       ]],
     ]
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,7 +75,8 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  config.warnings = true
+  # config.warnings = true
+  config.warnings = false
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
Incorporate dry-validation validation rules into the form AST (regardless of whether the input is actually validated). This will allow clever things on the front-end like field hints and client-side validation.

The form AST output has been updated during this change, but also now includes yardoc docs so the new parameter ordering should be easy to understand :)

Resolves #5.