### PR TITLE
[WIP] Require a dry-validation schema, and offer validated/unvalidated results

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 # Gem dependencies are specified in formalist.gemspec
 gemspec
 
+# Lock to a version of dry-v that'll offer the AST/error message structures we expect
+gem "dry-validation", git: "https://github.com/dryrb/dry-validation", ref: "6447302f3b53766b29f29230831890a5cc3822e0"
+
 group :tools do
   gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source "https://rubygems.org"
 # Gem dependencies are specified in formalist.gemspec
 gemspec
 
+gem "dry-validation", git: "https://github.com/dryrb/dry-validation", branch: "master"
+
 group :tools do
   gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source "https://rubygems.org"
 # Gem dependencies are specified in formalist.gemspec
 gemspec
 
-gem "dry-validation", git: "https://github.com/dryrb/dry-validation", branch: "master"
-
 group :tools do
   gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: https://github.com/dryrb/dry-validation
-  revision: 3775ee4d05e9b0f18368197e63f8e103cc43dfc1
-  branch: master
-  specs:
-    dry-validation (0.6.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-      dry-container (~> 0.2, >= 0.2.8)
-      dry-data (~> 0.5, >= 0.5.0)
-      dry-equalizer (~> 0.2)
-      dry-logic (~> 0.1, >= 0.1.4)
-
 PATH
   remote: .
   specs:
@@ -17,7 +5,7 @@ PATH
       dry-configurable
       dry-container
       dry-data (>= 0.4.2)
-      dry-validation
+      dry-validation (~> 0.6.0)
       inflecto
 
 GEM
@@ -47,6 +35,12 @@ GEM
     dry-logic (0.1.4)
       dry-container (~> 0.2, >= 0.2.6)
       dry-equalizer (~> 0.2)
+    dry-validation (0.6.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
+      dry-container (~> 0.2, >= 0.2.8)
+      dry-data (~> 0.5, >= 0.5.0)
+      dry-equalizer (~> 0.2)
+      dry-logic (~> 0.1, >= 0.1.2)
     inflecto (0.0.2)
     json (1.8.3)
     kleisli (0.2.7)
@@ -95,7 +89,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   byebug
-  dry-validation!
   formalist!
   pry
   rake (~> 10.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/dryrb/dry-validation
+  revision: 6447302f3b53766b29f29230831890a5cc3822e0
+  ref: 6447302f3b53766b29f29230831890a5cc3822e0
+  specs:
+    dry-validation (0.6.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
+      dry-container (~> 0.2, >= 0.2.8)
+      dry-data (~> 0.5, >= 0.5.0)
+      dry-equalizer (~> 0.2)
+      dry-logic (~> 0.1, >= 0.1.4)
+
 PATH
   remote: .
   specs:
@@ -35,12 +47,6 @@ GEM
     dry-logic (0.1.4)
       dry-container (~> 0.2, >= 0.2.6)
       dry-equalizer (~> 0.2)
-    dry-validation (0.6.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-      dry-container (~> 0.2, >= 0.2.8)
-      dry-data (~> 0.5, >= 0.5.0)
-      dry-equalizer (~> 0.2)
-      dry-logic (~> 0.1, >= 0.1.2)
     inflecto (0.0.2)
     json (1.8.3)
     kleisli (0.2.7)
@@ -89,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   byebug
+  dry-validation!
   formalist!
   pry
   rake (~> 10.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/dryrb/dry-validation
+  revision: 3775ee4d05e9b0f18368197e63f8e103cc43dfc1
+  branch: master
+  specs:
+    dry-validation (0.6.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
+      dry-container (~> 0.2, >= 0.2.8)
+      dry-data (~> 0.5, >= 0.5.0)
+      dry-equalizer (~> 0.2)
+      dry-logic (~> 0.1, >= 0.1.4)
+
 PATH
   remote: .
   specs:
@@ -18,23 +30,22 @@ GEM
     coderay (1.1.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    dry-configurable (0.1.2)
+    dry-configurable (0.1.3)
       thread_safe
-    dry-container (0.2.7)
-      dry-configurable (= 0.1.2)
+    dry-container (0.2.8)
+      dry-configurable (~> 0.1, >= 0.1.3)
       thread_safe
-    dry-data (0.4.2)
+    dry-data (0.5.1)
       dry-configurable (~> 0.1)
       dry-container (~> 0.2)
       dry-equalizer (~> 0.2)
+      dry-logic (~> 0.1)
       inflecto (~> 0.0.0, >= 0.0.2)
       kleisli (~> 0.2)
       thread_safe (~> 0.3)
     dry-equalizer (0.2.0)
-    dry-validation (0.4.1)
-      dry-configurable (~> 0.1)
+    dry-logic (0.1.4)
       dry-container (~> 0.2, >= 0.2.6)
-      dry-data (~> 0.4, >= 0.4.2)
       dry-equalizer (~> 0.2)
     inflecto (0.0.2)
     json (1.8.3)
@@ -84,6 +95,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   byebug
+  dry-validation!
   formalist!
   pry
   rake (~> 10.4.2)

--- a/formalist.gemspec
+++ b/formalist.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable"
   spec.add_runtime_dependency "dry-container"
   spec.add_runtime_dependency "dry-data", ">= 0.4.2"
-  spec.add_runtime_dependency "dry-validation"
+  spec.add_runtime_dependency "dry-validation", "~> 0.6.0"
   spec.add_runtime_dependency "inflecto"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -38,7 +38,7 @@ module Formalist
     end
 
     def receive(form_post)
-      input = schema.(form_post).params
+      input = schema.(form_post).output
       build(input)
     end
   end

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -21,15 +21,25 @@ module Formalist
     end
 
     # @api private
+    attr_reader :schema
+
+    # @api private
     attr_reader :elements
 
-    def initialize
+    def initialize(schema)
       definition_compiler = DefinitionCompiler.new(self.class.display_adapters)
+
       @elements = definition_compiler.call(self.class.elements)
+      @schema = schema
     end
 
-    def call(input = {}, rules: [], errors: {})
-      Result.new(elements.map { |el| el.(input, rules, errors) })
+    def build(input)
+      Result.new(schema, elements, input)
+    end
+
+    def receive(form_post)
+      input = schema.(form_post).params
+      build(input)
     end
   end
 end

--- a/lib/formalist/form/result.rb
+++ b/lib/formalist/form/result.rb
@@ -1,14 +1,45 @@
+require "formalist/form/validated_result"
+
 module Formalist
   class Form
     class Result
+      # @api private
+      attr_reader :input
+
+      # @api private
+      attr_reader :schema
+
+      # @api private
       attr_reader :elements
 
-      def initialize(elements)
+      # @api public
+      attr_reader :validation
+
+      def initialize(schema, elements, input)
+        @input = input
+        @schema = schema
         @elements = elements
+        @validation = schema.(input)
+      end
+
+      def output
+        validation.output
+      end
+
+      def success?
+        true
+      end
+
+      def messages
+        {}
       end
 
       def to_ast
-        elements.map(&:to_ast)
+        elements.map { |el| el.(output, schema.rules.map(&:to_ary), messages).to_ast }
+      end
+
+      def validate
+        ValidatedResult.new(self)
       end
     end
   end

--- a/lib/formalist/form/result.rb
+++ b/lib/formalist/form/result.rb
@@ -7,8 +7,8 @@ module Formalist
         @elements = elements
       end
 
-      def to_ary
-        elements.map(&:to_ary)
+      def to_ast
+        elements.map(&:to_ast)
       end
     end
   end

--- a/lib/formalist/form/result.rb
+++ b/lib/formalist/form/result.rb
@@ -23,7 +23,7 @@ module Formalist
       end
 
       def output
-        validation.output
+        validation.params
       end
 
       def success?

--- a/lib/formalist/form/result.rb
+++ b/lib/formalist/form/result.rb
@@ -23,7 +23,7 @@ module Formalist
       end
 
       def output
-        validation.params
+        validation.output
       end
 
       def success?

--- a/lib/formalist/form/result/attr.rb
+++ b/lib/formalist/form/result/attr.rb
@@ -40,7 +40,7 @@ module Formalist
         # 1. Child form elements
         #
         # @example "metadata" attr
-        #   attr.to_ary # =>
+        #   attr.to_ast # =>
         #   # [:attr, [
         #   #   :metadata,
         #   #   [
@@ -53,7 +53,7 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the attribute as an array.
-        def to_ary
+        def to_ast
           # Errors, if the attr hash is present and its members have errors:
           # {:meta=>[[{:pages=>[["pages is missing"], nil]}], {}]}
 
@@ -66,7 +66,7 @@ module Formalist
             definition.name,
             value_predicates,
             local_errors,
-            children.map(&:to_ary),
+            children.map(&:to_ast),
           ]]
         end
 

--- a/lib/formalist/form/result/component.rb
+++ b/lib/formalist/form/result/component.rb
@@ -28,7 +28,7 @@ module Formalist
         # 1. Child form elements
         #
         # @example
-        #   component.to_ary # =>
+        #   component.to_ast # =>
         #   # [:component, [
         #   #   [
         #   #     [:some_config_name, :some_config_value]
@@ -39,10 +39,10 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the component as an array.
-        def to_ary
+        def to_ast
           [:component, [
             definition.config.to_a,
-            children.map(&:to_ary),
+            children.map(&:to_ast),
           ]]
         end
       end

--- a/lib/formalist/form/result/field.rb
+++ b/lib/formalist/form/result/field.rb
@@ -38,7 +38,7 @@ module Formalist
         # 1. Field configuration
         #
         # @example "email" field
-        #   field.to_ary # =>
+        #   field.to_ast # =>
         #   # [:field, [
         #   #   :email,
         #   #   "string",
@@ -57,7 +57,7 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the field as an array.
-        def to_ary
+        def to_ast
           # errors looks like this
           # {:field_name => [["pages is missing", "another error message"], nil]}
 

--- a/lib/formalist/form/result/group.rb
+++ b/lib/formalist/form/result/group.rb
@@ -28,7 +28,7 @@ module Formalist
         # 1. Child form elements
         #
         # @example
-        #   group.to_ary # =>
+        #   group.to_ast # =>
         #   # [:group, [
         #   #   [
         #   #     [:some_config_name, :some_config_value]
@@ -39,10 +39,10 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the group as an array.
-        def to_ary
+        def to_ast
           [:group, [
             definition.config.to_a,
-            children.map(&:to_ary),
+            children.map(&:to_ast),
           ]]
         end
       end

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -97,25 +97,21 @@ module Formalist
 
         def build_children
           # child errors looks like this:
-          # {:links=>
-          #   [[{:links=>
-          #       [[{:url=>[["url must be filled"], ""]}],
-          #        {:name=>"personal", :url=>""}]}],
-          #    [{:name=>"company", :url=>"http://icelab.com.au"},
-          #     {:name=>"personal", :url=>""}]]}
+          # [
+          #   {:rating=>[["rating must be greater than or equal to 1"], 0]},
+          #   {:summary=>"Great", :rating=>0},
+          #   {:summary=>[["summary must be filled"], ""]},
+          #   {:summary=>"", :rating=>1}
+          # ]
           #
           # or local errors:
           # {:links=>[["links is missing"], nil]}
 
-          child_errors = errors[0].is_a?(Hash) ? errors : {}
+          child_errors = errors.each_slice(2).to_a
 
           input.map { |child_input|
             local_child_errors = child_errors.select { |e|
-              e.is_a?(Hash)
-            }.map { |e|
-              e[definition.name]
-            }.detect { |e|
-              e && e[1] == child_input
+              e[1] == child_input
             }.to_a.dig(0, 0) || {}
 
             definition.children.map { |el| el.(child_input, collection_rules, local_child_errors) }

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -46,7 +46,7 @@ module Formalist
         #    none, if there is no or empty input data)
         #
         # @example "locations" collection
-        #   many.to_ary # =>
+        #   many.to_ast # =>
         #   # [:many, [
         #   #   :locations,
         #   #   [[:predicate, [:min_size?, [3]]]],
@@ -73,7 +73,7 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the collection as an array.
-        def to_ary
+        def to_ast
           local_errors = errors.select { |e| e.is_a?(String) }
 
           [:many, [
@@ -81,8 +81,8 @@ module Formalist
             value_predicates,
             local_errors,
             definition.config.to_a,
-            child_template.map(&:to_ary),
-            children.map { |el_list| el_list.map(&:to_ary) },
+            child_template.map(&:to_ast),
+            children.map { |el_list| el_list.map(&:to_ast) },
           ]]
         end
 

--- a/lib/formalist/form/result/many.rb
+++ b/lib/formalist/form/result/many.rb
@@ -115,7 +115,7 @@ module Formalist
             }.map { |e|
               e[definition.name]
             }.detect { |e|
-              e[1] == child_input
+              e && e[1] == child_input
             }.to_a.dig(0, 0) || {}
 
             definition.children.map { |el| el.(child_input, collection_rules, local_child_errors) }

--- a/lib/formalist/form/result/section.rb
+++ b/lib/formalist/form/result/section.rb
@@ -29,7 +29,7 @@ module Formalist
         # 1. Child form elements
         #
         # @example "content" section
-        #   section.to_ary # =>
+        #   section.to_ast # =>
         #   # [:section, [
         #   #   :content,
         #   #   [
@@ -41,11 +41,11 @@ module Formalist
         #   # ]]
         #
         # @return [Array] the section as an array.
-        def to_ary
+        def to_ast
           [:section, [
             definition.name,
             definition.config.to_a,
-            children.map(&:to_ary),
+            children.map(&:to_ast),
           ]]
         end
       end

--- a/lib/formalist/form/validated_result.rb
+++ b/lib/formalist/form/validated_result.rb
@@ -1,0 +1,35 @@
+require "forwardable"
+
+module Formalist
+  class Form
+    class ValidatedResult
+      extend Forwardable
+
+      def_delegators :@result,
+        :input,
+        :schema,
+        :elements,
+        :validation,
+        :output
+
+      # @api private
+      attr_reader :result
+
+      def initialize(result)
+        @result = result
+      end
+
+      def success?
+        validation.success?
+      end
+
+      def messages
+        validation.messages
+      end
+
+      def to_ast
+        elements.map { |el| el.(output, schema.rules.map(&:to_ary), messages).to_ast }
+      end
+    end
+  end
+end

--- a/lib/formalist/validation/value_rules_compiler.rb
+++ b/lib/formalist/validation/value_rules_compiler.rb
@@ -26,6 +26,10 @@ module Formalist
 
       def visit_val(node)
         name, predicate = node
+
+        # Support names that show as keypaths, e.g. [:reviews, :rating]
+        name = name.last if name.is_a?(Array)
+
         return [] unless name == target_name
 
         # Skip the "val" prefix

--- a/spec/integration/display_adapters_spec.rb
+++ b/spec/integration/display_adapters_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Display adapters" do
   }
 
   it "outputs an AST" do
-    expect(form.({}).to_ary).to eq [
+    expect(form.({}).to_ast).to eq [
       [:field, [
         :temperature_unit,
         "string",
@@ -41,7 +41,7 @@ RSpec.describe "Display adapters" do
       field :email, type: "string"
     end.new
 
-    expect(form.({}).to_ary).to eq [
+    expect(form.({}).to_ast).to eq [
       [:field, [:name, "string", "custom", nil, [], [], []]],
       [:field, [:email, "string", "default", nil, [], [], []]],
     ]

--- a/spec/integration/display_adapters_spec.rb
+++ b/spec/integration/display_adapters_spec.rb
@@ -1,12 +1,18 @@
 RSpec.describe "Display adapters" do
-  subject(:form) {
-    Class.new(Formalist::Form) do
-      field :temperature_unit, type: "string", display: "select", option_values: [%w[c c], %w[f f]]
+  let(:schema) {
+    Class.new(Dry::Validation::Schema) do
+      key(:temperature_unit)
     end.new
   }
 
+  subject(:form) {
+    Class.new(Formalist::Form) do
+      field :temperature_unit, type: "string", display: "select", option_values: [%w[c c], %w[f f]]
+    end.new(schema)
+  }
+
   it "outputs an AST" do
-    expect(form.({}).to_ast).to eq [
+    expect(form.build({}).to_ast).to eq [
       [:field, [
         :temperature_unit,
         "string",
@@ -39,9 +45,9 @@ RSpec.describe "Display adapters" do
 
       field :name, type: "string", display: "custom"
       field :email, type: "string"
-    end.new
+    end.new(schema)
 
-    expect(form.({}).to_ast).to eq [
+    expect(form.build({}).to_ast).to eq [
       [:field, [:name, "string", "custom", nil, [], [], []]],
       [:field, [:email, "string", "default", nil, [], [], []]],
     ]

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Formalist::Form do
   }
 
   it "outputs an AST" do
-    expect(form.(title: "Aurora", rating:  10).to_ary).to eq [
+    expect(form.(title: "Aurora", rating:  10).to_ast).to eq [
       [:component, [
         [],
         [

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -1,20 +1,29 @@
 RSpec.describe Formalist::Form do
+  let(:schema) {
+    Class.new(Dry::Validation::Schema) do
+      key(:title, &:str?)
+      key(:rating, &:int?)
+    end.new
+  }
+
   subject(:form) {
     Class.new(Formalist::Form) do
       component do |c|
         c.field :title, type: "string"
         c.field :rating, type: "int"
       end
-    end.new
+    end.new(schema)
   }
 
   it "outputs an AST" do
-    expect(form.(title: "Aurora", rating:  10).to_ast).to eq [
+    ast = form.build(title: "Aurora", rating:  10).to_ast
+
+    expect(form.build(title: "Aurora", rating:  10).to_ast).to eq [
       [:component, [
         [],
         [
-          [:field, [:title, "string", "default", "Aurora", [], [], []]],
-          [:field, [:rating, "int", "default", 10, [], [], []]]
+          [:field, [:title, "string", "default", "Aurora", [[:predicate, [:str?, []]]], [], []]],
+          [:field, [:rating, "int", "default", 10, [[:predicate, [:int?, []]]], [], []]]
         ],
       ]],
     ]

--- a/spec/integration/validation_spec.rb
+++ b/spec/integration/validation_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "Form validation" do
       # TODO: uncomment/fix the "meta" related sections (here and below) once
       # we have a clarification on dryrb/dry-validation#58.
       #
-      key(:meta) do |meta|
-        meta.key(:pages) { |pages| pages.filled? }
-      end
+      # key(:meta) do |meta|
+      #   meta.key(:pages) { |pages| pages.filled? }
+      # end
     end.new
   }
 
@@ -35,9 +35,9 @@ RSpec.describe "Form validation" do
         review.field :rating, type: "int"
       end
 
-      attr :meta do |meta|
-        meta.field :pages, type: "int"
-      end
+      # attr :meta do |meta|
+      #   meta.field :pages, type: "int"
+      # end
     end.new(schema)
   }
 
@@ -74,13 +74,13 @@ RSpec.describe "Form validation" do
           ]
         ],
       ]],
-      [:attr, [:meta,
-        [],
-        [],
-        [
-          [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
-        ],
-      ]]
+      # [:attr, [:meta,
+      #   [],
+      #   [],
+      #   [
+      #     [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
+      #   ],
+      # ]]
     ]
   end
 end

--- a/spec/integration/validation_spec.rb
+++ b/spec/integration/validation_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Form validation" do
       meta: {pages: nil}
     }
 
-    expect(form.call(input).to_ary).to eq [
+    expect(form.call(input).to_ast).to eq [
       [:field, [:title, "string", "default", nil, [[:predicate, [:filled?, []]]], ["title is missing"], []]],
       [:field, [:rating, "int", "default", nil, [[:and, [[:predicate, [:gteq?, [1]]], [:predicate, [:lteq?, [10]]]]]], ["rating is missing", "rating must be greater than or equal to 1", "rating must be less than or equal to 10"], []]],
       [:many, [:reviews,

--- a/spec/integration/validation_spec.rb
+++ b/spec/integration/validation_spec.rb
@@ -16,9 +16,12 @@ RSpec.describe "Form validation" do
 
       end
 
-      key(:meta) do |meta|
-        meta.key(:pages) { |pages| pages.filled? }
-      end
+      # TODO: uncomment/fix the "meta" related sections (here and below) once
+      # we have a clarification on dryrb/dry-validation#58.
+      #
+      # key(:meta) do |meta|
+      #   meta.key(:pages) { |pages| pages.filled? }
+      # end
     end.new
   }
 
@@ -32,10 +35,10 @@ RSpec.describe "Form validation" do
         review.field :rating, type: "int"
       end
 
-      attr :meta do |meta|
-        meta.field :pages, type: "int"
-      end
-    end.new(schema: schema)
+      # attr :meta do |meta|
+      #   meta.field :pages, type: "int"
+      # end
+    end.new(schema)
   }
 
   it "includes validation rules and errors in the AST" do
@@ -44,7 +47,7 @@ RSpec.describe "Form validation" do
       meta: {pages: nil}
     }
 
-    expect(form.call(input).to_ast).to eq [
+    expect(form.build(input).validate.to_ast).to eq [
       [:field, [:title, "string", "default", nil, [[:predicate, [:filled?, []]]], ["title is missing"], []]],
       [:field, [:rating, "int", "default", nil, [[:and, [[:predicate, [:gteq?, [1]]], [:predicate, [:lteq?, [10]]]]]], ["rating is missing", "rating must be greater than or equal to 1", "rating must be less than or equal to 10"], []]],
       [:many, [:reviews,
@@ -71,13 +74,13 @@ RSpec.describe "Form validation" do
           ]
         ],
       ]],
-      [:attr, [:meta,
-        [],
-        [],
-        [
-          [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
-        ],
-      ]]
+      # [:attr, [:meta,
+      #   [],
+      #   [],
+      #   [
+      #     [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
+      #   ],
+      # ]]
     ]
   end
 end

--- a/spec/integration/validation_spec.rb
+++ b/spec/integration/validation_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "Form validation" do
       # TODO: uncomment/fix the "meta" related sections (here and below) once
       # we have a clarification on dryrb/dry-validation#58.
       #
-      # key(:meta) do |meta|
-      #   meta.key(:pages) { |pages| pages.filled? }
-      # end
+      key(:meta) do |meta|
+        meta.key(:pages) { |pages| pages.filled? }
+      end
     end.new
   }
 
@@ -35,9 +35,9 @@ RSpec.describe "Form validation" do
         review.field :rating, type: "int"
       end
 
-      # attr :meta do |meta|
-      #   meta.field :pages, type: "int"
-      # end
+      attr :meta do |meta|
+        meta.field :pages, type: "int"
+      end
     end.new(schema)
   }
 
@@ -74,13 +74,13 @@ RSpec.describe "Form validation" do
           ]
         ],
       ]],
-      # [:attr, [:meta,
-      #   [],
-      #   [],
-      #   [
-      #     [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
-      #   ],
-      # ]]
+      [:attr, [:meta,
+        [],
+        [],
+        [
+          [:field, [:pages, "int", "default", nil, [[:predicate, [:filled?, []]]], ["pages must be filled"], []]]
+        ],
+      ]]
     ]
   end
 end

--- a/spec/unit/output_compiler_spec.rb
+++ b/spec/unit/output_compiler_spec.rb
@@ -1,6 +1,25 @@
 RSpec.describe Formalist::OutputCompiler do
   subject(:compiler) { Formalist::OutputCompiler.new }
 
+  let(:schema) {
+    Class.new(Dry::Validation::Schema) do
+      key(:title, &:str?)
+      key(:rating, &:int?)
+
+      key(:reviews) do |reviews|
+        reviews.each do |review|
+          review.key(:description, &:str?)
+          review.key(:rating, &:int?)
+        end
+      end
+
+      key(:meta) do |meta|
+        meta.key(:pages, &:int?)
+        meta.key(:publisher, &:str?)
+      end
+    end.new
+  }
+
   let(:form) {
     Class.new(Formalist::Form) do
       field :title, type: "string"
@@ -19,7 +38,7 @@ RSpec.describe Formalist::OutputCompiler do
           end
         end
       end
-    end.new
+    end.new(schema)
   }
 
   let(:input) {
@@ -43,7 +62,7 @@ RSpec.describe Formalist::OutputCompiler do
     }
   }
 
-  let(:ast) { form.call(input).to_ast }
+  let(:ast) { form.build(input).to_ast }
 
   it "works" do
     expect(compiler.call(ast)).to eq input

--- a/spec/unit/output_compiler_spec.rb
+++ b/spec/unit/output_compiler_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Formalist::OutputCompiler do
     }
   }
 
-  let(:ast) { form.call(input).to_ary }
+  let(:ast) { form.call(input).to_ast }
 
   it "works" do
     expect(compiler.call(ast)).to eq input


### PR DESCRIPTION
:hand: :warning: :construction: :hand:

This requires every form to have a corresponding dry-validation schema. The ultimate goal is to remove any type coercion work from formalist itself and rely on dry-validation's own type coercions.

It also changes the API to better support the two distinct use cases you have with a form:

1. Preparing a form with sane, initial input from your database and sending it to the view for rendering.

    ```ruby
    my_form = MyForm.new(my_schema)
    my_form.build(input) # returns a `Formalist::Form::Result`
    ```
2. Then, receiving the data from the posted form, coercing it and validating it (and potentially re-displaying the form with errors):

    ```ruby
    my_form = MyForm.new(my_schema)
    my_form.receive(input).validate # returns a `Formalist::Form::ValidatedResult`
    ```

The main differences are as such:

* `#build` expects already-clean (e.g. properly structured and typed) data
* `#receive` expects the kind of data that your form will submit, and will then coerce it according to the validation schema, and then send the sanitised output to `#build`
* Calling `#validate` on a result object will validate the input data and include any error messages in its AST

So far, all of the above is in place and working.

What's left to do is:

- [ ] Adjust our `CollectionRulesCompiler` depending on whether `:set` remains in dry-validation's rules AST (pending clarification in dryrb/dry-validation#58).
- [x] Work out how we _actually_ want to submit our form data (i.e. our discussion in #20) – do we want to submit a whole AST back or some simplified HTML post structure.
- [x] Based on the above, modify `#build` to actually coerce that input.
- [x] Remove the dry-data type definition from our fields.
- [ ] Extract type definition from the schema and include it in lieu of our previous explicitly provided type
- [ ] Change the display types so they are more prominent in the absence of any type information (e.g. make them required).