### PR TITLE
Change attributes

### DIFF
--- a/lib/formalist/elements/attr.rb
+++ b/lib/formalist/elements/attr.rb
@@ -12,6 +12,8 @@ module Formalist
       # @api private
       attr_reader :name
 
+      attribute :label Types::String
+
       # @api private
       attr_reader :value_rules, :value_predicates, :collection_rules, :child_errors
 

--- a/lib/formalist/elements/attr.rb
+++ b/lib/formalist/elements/attr.rb
@@ -12,7 +12,7 @@ module Formalist
       # @api private
       attr_reader :name
 
-      attribute :label Types::String
+      attribute :label, Types::String
 
       # @api private
       attr_reader :value_rules, :value_predicates, :collection_rules, :child_errors

--- a/lib/formalist/elements/field.rb
+++ b/lib/formalist/elements/field.rb
@@ -14,6 +14,7 @@ module Formalist
       attribute :label, Types::String
       attribute :hint, Types::String
       attribute :placeholder, Types::String
+      attribute :inline, Types::Bool
 
       # @api private
       attr_reader :predicates

--- a/lib/formalist/elements/group.rb
+++ b/lib/formalist/elements/group.rb
@@ -6,7 +6,7 @@ module Formalist
     class Group < Element
       permitted_children :attr, :compound_field, :field, :many
 
-      attribute :label, Types::ElementString
+      attribute :label, Types::String
 
       # Converts the group into an abstract syntax tree.
       #

--- a/lib/formalist/elements/group.rb
+++ b/lib/formalist/elements/group.rb
@@ -6,6 +6,8 @@ module Formalist
     class Group < Element
       permitted_children :attr, :compound_field, :field, :many
 
+      attribute :label, Types::ElementString
+
       # Converts the group into an abstract syntax tree.
       #
       # It takes the following format:

--- a/lib/formalist/elements/many.rb
+++ b/lib/formalist/elements/many.rb
@@ -12,6 +12,7 @@ module Formalist
       # @api private
       attr_reader :name
 
+      attribute :label, Types::ElementString
       attribute :allow_create, Types::Bool
       attribute :allow_update, Types::Bool
       attribute :allow_destroy, Types::Bool

--- a/lib/formalist/elements/many.rb
+++ b/lib/formalist/elements/many.rb
@@ -12,7 +12,7 @@ module Formalist
       # @api private
       attr_reader :name
 
-      attribute :label, Types::ElementString
+      attribute :label, Types::String
       attribute :allow_create, Types::Bool
       attribute :allow_update, Types::Bool
       attribute :allow_destroy, Types::Bool

--- a/lib/formalist/elements/section.rb
+++ b/lib/formalist/elements/section.rb
@@ -9,7 +9,7 @@ module Formalist
       # @api private
       attr_reader :name
 
-      attribute :label, Types::ElementString
+      attribute :label, Types::String
 
       def initialize(*args, attributes, children, input, rules, errors)
         super

--- a/lib/formalist/elements/section.rb
+++ b/lib/formalist/elements/section.rb
@@ -9,6 +9,8 @@ module Formalist
       # @api private
       attr_reader :name
 
+      attribute :label, Types::ElementString
+
       def initialize(*args, attributes, children, input, rules, errors)
         super
 

--- a/lib/formalist/elements/standard/text_area.rb
+++ b/lib/formalist/elements/standard/text_area.rb
@@ -7,6 +7,7 @@ module Formalist
     class TextArea < Field
       attribute :text_size, Types::String.enum("xsmall", "small", "normal", "large", "xlarge"), default: "normal"
       attribute :box_size, Types::String.enum("single", "small", "normal", "large", "xlarge"), default: "normal"
+      attribute :code Types::Bool
     end
 
     register :text_area, TextArea

--- a/lib/formalist/elements/standard/text_area.rb
+++ b/lib/formalist/elements/standard/text_area.rb
@@ -7,7 +7,7 @@ module Formalist
     class TextArea < Field
       attribute :text_size, Types::String.enum("xsmall", "small", "normal", "large", "xlarge"), default: "normal"
       attribute :box_size, Types::String.enum("single", "small", "normal", "large", "xlarge"), default: "normal"
-      attribute :code Types::Bool
+      attribute :code, Types::Bool
     end
 
     register :text_area, TextArea

--- a/lib/formalist/elements/standard/text_field.rb
+++ b/lib/formalist/elements/standard/text_field.rb
@@ -6,7 +6,7 @@ module Formalist
   class Elements
     class TextField < Field
       attribute :password, Types::Bool
-      attribute :code Types::Bool
+      attribute :code, Types::Bool
     end
 
     register :text_field, TextField

--- a/lib/formalist/elements/standard/text_field.rb
+++ b/lib/formalist/elements/standard/text_field.rb
@@ -6,7 +6,6 @@ module Formalist
   class Elements
     class TextField < Field
       attribute :password, Types::Bool
-      attribute :inline, Types::Bool
     end
 
     register :text_field, TextField

--- a/lib/formalist/elements/standard/text_field.rb
+++ b/lib/formalist/elements/standard/text_field.rb
@@ -6,6 +6,7 @@ module Formalist
   class Elements
     class TextField < Field
       attribute :password, Types::Bool
+      attribute :code Types::Bool
     end
 
     register :text_field, TextField


### PR DESCRIPTION
* Allows a `label` attribute to any of the entities that can be `name`d, so we can have nicely formatted labels where it makes sense.
* Also adds `label` to groups, as it’s something that makes sense as an optional attr.
* Made all fields allow `inline: true`. I think this is reasonable as a global option for fields. It’s ignorable in UI if it doesn’t make sense anyway.
* Adds `code: true` attributes to text-type fields.