### PR TITLE
Adjust allowed attributes for the `many`

### DIFF
--- a/lib/formalist/elements/many.rb
+++ b/lib/formalist/elements/many.rb
@@ -10,7 +10,7 @@ module Formalist
       attr_reader :name
 
       attribute :label, Types::String
-      attribute :add_label, Types::String
+      attribute :action_label, Types::String
       attribute :placeholder, Types::String
       attribute :validation, Types::Validation
 

--- a/lib/formalist/elements/many.rb
+++ b/lib/formalist/elements/many.rb
@@ -10,10 +10,8 @@ module Formalist
       attr_reader :name
 
       attribute :label, Types::String
-      attribute :allow_create, Types::Bool
-      attribute :allow_update, Types::Bool
-      attribute :allow_destroy, Types::Bool
-      attribute :allow_reorder, Types::Bool
+      attribute :add_label, Types::String
+      attribute :placeholder, Types::String
       attribute :validation, Types::Validation
 
       # @api private


### PR DESCRIPTION
Removes the various `allowed_` attributes and adds some simple display attributes.