### PR TITLE
Default check box values to false

### DIFF
--- a/lib/formalist/elements/standard/check_box.rb
+++ b/lib/formalist/elements/standard/check_box.rb
@@ -6,6 +6,13 @@ module Formalist
   class Elements
     class CheckBox < Field
       attribute :question_text, Types::String
+
+      def initialize(*)
+        super
+
+        # Ensure value is a boolean (also: default to false for nil values)
+        @input = !!@input
+      end
     end
 
     register :check_box, CheckBox

--- a/spec/unit/elements/standard/check_box_spec.rb
+++ b/spec/unit/elements/standard/check_box_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "formalist/elements/standard/check_box"
+
+RSpec.describe Formalist::Elements::CheckBox do
+  subject(:check_box) {
+    Formalist::Elements::CheckBox.new(:published, attributes, [], {published: input}, errors)
+  }
+
+  let(:attributes) { {} }
+  let(:input) { nil }
+  let(:errors) { {} }
+
+  describe "input" do
+    context "is nil" do
+      specify { expect(check_box.input).to eql false }
+    end
+
+    context "is false" do
+      let(:input) { false }
+      specify { expect(check_box.input).to eql false }
+    end
+
+    context "is true" do
+      let(:input) { true }
+      specify { expect(check_box.input).to eql true }
+    end
+
+    context "is any other value" do
+      let(:input) { "something" }
+      specify { expect(check_box.input).to eql true }
+    end
+  end
+end


### PR DESCRIPTION
The formalist UI JS libraries are strict about how they interpret input values. If we pass `nil` for the check box values, that becomes `null` there, which does not equate to an actual false/unchecked state for the checkboxes. This means that they need to be checked and then unchecked again in order to submit an actual value.

This change should fix this, by setting a proper true/false value on checkboxes for any input type (which means a `nil` input will default to `false`).