### PR TITLE
Add temporary fix for rendering embedded form data

### DIFF
--- a/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
+++ b/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
@@ -13,6 +13,11 @@ module Formalist
         def call(form_data)
           type, data = form_data.values_at("name", "data")
 
+          # FIXME: temporary fix for handling form_data keys
+          # as either strings or symbols.
+          type = form_data[:name] unless type
+          data = form_data[:data] unless data
+
           if container.key?(type)
             container[type].(data, render_options)
           else


### PR DESCRIPTION
The form data arrives here either with symbol keys (when it has come via the previous quick fix) or symbol keys (when it has not).

We obviously need a proper solution here but this is a quick fix for getting things running today. 