### PR TITLE
Embedded form input processor

### DIFF
--- a/lib/formalist/elements/standard/rich_text_area.rb
+++ b/lib/formalist/elements/standard/rich_text_area.rb
@@ -13,17 +13,7 @@ module Formalist
 
       # FIXME: it would be tidier to have a reader method for each attribute
       def attributes
-        # Replace the form objects with their AST
         super.merge(embeddable_forms: embeddable_forms_config)
-      end
-
-      def embeddable_forms_config
-        Hash(@attributes[:embeddable_forms].to_h).map { |key, attrs|
-          original_attrs = attrs
-          adjusted_attrs = original_attrs.merge(form: original_attrs[:form].build.to_ast)
-
-          [key, adjusted_attrs]
-        }.to_h
       end
 
       def input
@@ -32,6 +22,14 @@ module Formalist
 
       private
 
+      # Replace the form objects with their AST
+      def embeddable_forms_config
+        @attributes[:embeddable_forms].to_h.map { |key, attrs|
+          [key, attrs.merge(form: attrs[:form].build.to_ast)]
+        }.to_h
+      end
+
+      # TODO: make compiler configurable somehow?
       def input_compiler
         RichText::EmbeddedFormCompiler.new(@attributes[:embeddable_forms])
       end

--- a/lib/formalist/rich_text/embedded_form_compiler.rb
+++ b/lib/formalist/rich_text/embedded_form_compiler.rb
@@ -3,8 +3,11 @@ require "json"
 module Formalist
   module RichText
 
-    # Our input data looks like this (this is a text line, embedded form data,
-    # then another text line):
+    # Our input data looks like this example, which consists of 3 elements:
+    #
+    # 1. A text line
+    # 2. embedded form data
+    # 3. Another text line
     #
     # [
     #   ["block",["unstyled","b14hd",[["inline",[[],"Before!"]]]]],
@@ -12,8 +15,8 @@ module Formalist
     #   ["block",["unstyled","aivqi",[["inline",[[],"After!"]]]]]
     # ]
     #
-    # We want to intercept the embededed form data and turn them back into
-    # full form ASTs, complete with validation messages.
+    # We want to intercept the embededed form data and transform them into full
+    # form ASTs, complete with validation messages.
 
     class EmbeddedFormCompiler
       attr_reader :embedded_forms
@@ -26,6 +29,7 @@ module Formalist
         return ast if ast.nil?
 
         ast = ast.is_a?(String) ? JSON.parse(ast) : ast
+
         ast.map { |node| visit(node) }
       end
       alias_method :[], :call

--- a/lib/formalist/rich_text/embedded_form_compiler.rb
+++ b/lib/formalist/rich_text/embedded_form_compiler.rb
@@ -71,9 +71,15 @@ module Formalist
       end
 
       def prepare_form_ast(embedded_form, data)
-        input = embedded_form.schema.(data)
+        # Run the raw data through the validation schema
+        validation = embedded_form.schema.(data)
 
-        embedded_form.form.build(input.to_h, input.messages).to_ast
+        # And then through the embedded form's input processor (which may add
+        # extra system-generated information necessary for the form to render
+        # fully)
+        input = embedded_form.input_processor.(validation.to_h)
+
+        embedded_form.form.build(input, validation.messages).to_ast
       end
     end
   end

--- a/lib/formalist/rich_text/embedded_forms_container/mixin.rb
+++ b/lib/formalist/rich_text/embedded_forms_container/mixin.rb
@@ -24,8 +24,8 @@ module Formalist
             super(key.to_s)
           end
 
-          def register(key, label:, form:, schema:)
-            super(key.to_s, Registration.new(label, form, schema))
+          def register(key, **attrs)
+            super(key.to_s, Registration.new(attrs))
           end
 
           def to_h

--- a/lib/formalist/rich_text/embedded_forms_container/registration.rb
+++ b/lib/formalist/rich_text/embedded_forms_container/registration.rb
@@ -2,18 +2,27 @@ module Formalist
   module RichText
     class EmbeddedFormsContainer
       class Registration
+        DEFAULT_INPUT_PROCESSOR = -> input { input }.freeze
+
         attr_reader :label
         attr_reader :form
         attr_reader :schema
+        attr_reader :input_processor
 
-        def initialize(label, form, schema)
+        def initialize(label:, form:, schema:, input_processor: DEFAULT_INPUT_PROCESSOR)
           @label = label
           @form = form
           @schema = schema
+          @input_processor = input_processor
         end
 
         def to_h
-          {label: label, form: form, schema: schema}
+          {
+            label: label,
+            form: form,
+            schema: schema,
+            input_processor: input_processor,
+          }
         end
       end
     end


### PR DESCRIPTION
Add an "input processor" to embedded form registrations. This allows the form's data to be processed before it is incorporated into the form AST that we include into the rich text AST before showing the content in the rich text editor.

Applications can use this feature to provide extra, necessary, application-level data associated to the form data. For example, in the case of an "image" embedded form, the application would need to provide a "thumbnail_url" for the image form to display the thumbnail for the image.

Resolves #58