### PR TITLE
Correctly render links marked as `newWindow`

### DIFF
--- a/lib/formalist/rich_text/rendering/html_renderer.rb
+++ b/lib/formalist/rich_text/rendering/html_renderer.rb
@@ -107,7 +107,14 @@ module Formalist
         end
 
         def entity_link(data, children)
-          html_tag(:a, href: data[:url]) do
+          link_attrs = {
+            href: data[:url]
+          }
+          link_attrs = link_attrs.merge(
+            target: "_blank",
+            rel: "noopener"
+          ) if data[:newWindow]
+          html_tag(:a, link_attrs) do
             children.join
           end
         end


### PR DESCRIPTION
Checks for the presence of the `newWindow` attribute in the link and renders the appropriate additional attributes, so we end up with:

```html
<a href="/foo" target="_blank" rel="noopener">...
```

See https://mathiasbynens.github.io/rel-noopener/ for detail on `rel="noopener"`.