### PR TITLE
Fix rich text validity check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ rvm:
   - 2.4.0
   - 2.3.3
   - 2.2.6
-  - 2.1.10
   - jruby-9.1.6.0
 addons:
   code_climate:

--- a/formalist.gemspec
+++ b/formalist.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["README.md", "LICENSE.md", "Gemfile*", "Rakefile", "lib/**/*", "spec/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_runtime_dependency "dry-configurable", "~> 0.7"
   spec.add_runtime_dependency "dry-container", "~> 0.6"

--- a/lib/formalist/form/validity_check.rb
+++ b/lib/formalist/form/validity_check.rb
@@ -17,13 +17,13 @@ module Formalist
       def visit_attr(node)
         name, type, errors, attributes, children = node
 
-        errors.empty? && children.map { |child| visit(child) }.none?
+        errors.empty? && children.map { |child| visit(child) }.all?
       end
 
       def visit_compound_field(node)
         type, attributes, children = node
 
-        children.map { |child| visit(child) }.none?
+        children.map { |child| visit(child) }.all?
       end
 
       def visit_field(node)
@@ -35,19 +35,19 @@ module Formalist
       def visit_group(node)
         type, attributes, children = node
 
-        children.map { |child| visit(child) }.none?
+        children.map { |child| visit(child) }.all?
       end
 
       def visit_many(node)
         name, type, errors, attributes, child_template, children = node
 
-        errors.empty? && children.map { |child| visit(child) }.none?
+        errors.empty? && children.map { |child| visit(child) }.all?
       end
 
       def visit_section(node)
         name, type, attributes, children = node
 
-        children.map { |child| visit(child) }.none?
+        children.map { |child| visit(child) }.all?
       end
     end
   end

--- a/lib/formalist/form/validity_check.rb
+++ b/lib/formalist/form/validity_check.rb
@@ -15,37 +15,37 @@ module Formalist
       end
 
       def visit_attr(node)
-        name, type, errors, attributes, children = node
+        _name, _type, errors, _attributes, children = node
 
         errors.empty? && children.map { |child| visit(child) }.all?
       end
 
       def visit_compound_field(node)
-        type, attributes, children = node
+        _type, _attributes, children = node
 
         children.map { |child| visit(child) }.all?
       end
 
       def visit_field(node)
-        name, type, input, errors, attributes = node
+        _name, _type, _input, errors, _attributes = node
 
         errors.empty?
       end
 
       def visit_group(node)
-        type, attributes, children = node
+        _type, _attributes, children = node
 
         children.map { |child| visit(child) }.all?
       end
 
       def visit_many(node)
-        name, type, errors, attributes, child_template, children = node
+        _name, _type, errors, _attributes, _child_template, children = node
 
         errors.empty? && children.map { |child| visit(child) }.all?
       end
 
       def visit_section(node)
-        name, type, attributes, children = node
+        _name, _type, _attributes, children = node
 
         children.map { |child| visit(child) }.all?
       end


### PR DESCRIPTION
We had some reversed logic in the check for validity in child elements, which meant we'd never return a proper `true` result for a rich text area with fully valid embedded forms. Not all that useful 😬 