### PR TITLE
Add disabled as an attribute to TextField fields

### DIFF
--- a/lib/formalist/elements/standard/text_field.rb
+++ b/lib/formalist/elements/standard/text_field.rb
@@ -7,6 +7,7 @@ module Formalist
     class TextField < Field
       attribute :password, Types::Bool
       attribute :code, Types::Bool
+      attribute :disabled, Types::Bool
     end
 
     register :text_field, TextField


### PR DESCRIPTION
This PR allows us to pass through a `disabled` boolean attribute to text fields.