### PR TITLE
Support custom option controls on search selection fields

### DIFF
--- a/formalist.gemspec
+++ b/formalist.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable", "~> 0.7"
   spec.add_runtime_dependency "dry-core", "~> 0.4"
   spec.add_runtime_dependency "dry-container", "~> 0.6"
-  spec.add_runtime_dependency "dry-types", "~> 0.12"
+  spec.add_runtime_dependency "dry-types", "~> 0.13"
   spec.add_runtime_dependency "inflecto"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/formalist/elements/standard/number_field.rb
+++ b/lib/formalist/elements/standard/number_field.rb
@@ -5,7 +5,7 @@ require "formalist/types"
 module Formalist
   class Elements
     class NumberField < Field
-      Number = Types::Int | Types::Float
+      Number = Types::Integer | Types::Float
 
       attribute :step, Number
       attribute :min, Number

--- a/lib/formalist/elements/standard/search_multi_selection_field.rb
+++ b/lib/formalist/elements/standard/search_multi_selection_field.rb
@@ -7,6 +7,7 @@ module Formalist
     class SearchMultiSelectionField < Field
       attribute :selector_label, Types::String
       attribute :render_option_as, Types::String
+      attribute :render_option_control_as, Types::String
       attribute :render_selection_as, Types::String
       attribute :search_url, Types::String
       attribute :search_per_page, Types::Int

--- a/lib/formalist/elements/standard/search_multi_selection_field.rb
+++ b/lib/formalist/elements/standard/search_multi_selection_field.rb
@@ -10,9 +10,9 @@ module Formalist
       attribute :render_option_control_as, Types::String
       attribute :render_selection_as, Types::String
       attribute :search_url, Types::String
-      attribute :search_per_page, Types::Int
+      attribute :search_per_page, Types::Integer
       attribute :search_params, Types::Hash
-      attribute :search_threshold, Types::Int
+      attribute :search_threshold, Types::Integer
       attribute :selections, Types::Array
     end
 

--- a/lib/formalist/elements/standard/search_selection_field.rb
+++ b/lib/formalist/elements/standard/search_selection_field.rb
@@ -7,6 +7,7 @@ module Formalist
     class SearchSelectionField < Field
       attribute :selector_label, Types::String
       attribute :render_option_as, Types::String
+      attribute :render_option_control_as, Types::String
       attribute :render_selection_as, Types::String
       attribute :search_url, Types::String
       attribute :search_per_page, Types::Int

--- a/lib/formalist/elements/standard/search_selection_field.rb
+++ b/lib/formalist/elements/standard/search_selection_field.rb
@@ -10,9 +10,9 @@ module Formalist
       attribute :render_option_control_as, Types::String
       attribute :render_selection_as, Types::String
       attribute :search_url, Types::String
-      attribute :search_per_page, Types::Int
+      attribute :search_per_page, Types::Integer
       attribute :search_params, Types::Hash
-      attribute :search_threshold, Types::Int
+      attribute :search_threshold, Types::Integer
       attribute :selection, Types::Hash
     end
 

--- a/lib/formalist/elements/standard/tags_field.rb
+++ b/lib/formalist/elements/standard/tags_field.rb
@@ -6,9 +6,9 @@ module Formalist
   class Elements
     class TagsField < Field
       attribute :search_url, Types::String
-      attribute :search_per_page, Types::Int
+      attribute :search_per_page, Types::Integer
       attribute :search_params, Types::Hash
-      attribute :search_threshold, Types::Int
+      attribute :search_threshold, Types::Integer
     end
 
     register :tags_field, TagsField

--- a/spec/unit/rich_text/embedded_form_compiler_spec.rb
+++ b/spec/unit/rich_text/embedded_form_compiler_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Formalist::RichText::EmbeddedFormCompiler do
   }
 
   let(:schema) {
-    Dry::Validation.Form do
+    Dry::Validation.Params do
       required(:image_id).filled(:int?)
       required(:caption).filled(:str?)
     end


### PR DESCRIPTION
This adds support for `render_option_control_as` attributes on search selection fields.

It also introduces dry-types 0.13 compatibility, using `Types::Integer` and also `Dry::Validation.Params`.