### PR TITLE
Add support for custom time formats on date time fields.

### DIFF
--- a/lib/formalist/elements/standard/date_time_field.rb
+++ b/lib/formalist/elements/standard/date_time_field.rb
@@ -5,6 +5,8 @@ require "formalist/types"
 module Formalist
   class Elements
     class DateTimeField < Field
+      attribute :time_format, Types::String
+      attribute :human_time_format, Types::String
     end
 
     register :date_time_field, DateTimeField


### PR DESCRIPTION
This adds time_format and human_time_format attributes on date time fields, to enable support for: https://github.com/icelab/formalist-standard-react/pull/154