### PR TITLE
Use fetch to check for nil values in attributes

### DIFF
--- a/lib/formalist/element.rb
+++ b/lib/formalist/element.rb
@@ -25,7 +25,7 @@ module Formalist
 
       # Set supplied attributes or their defaults
       all_attributes = self.class.attributes_schema.each_with_object({}) { |(name, defn), memo|
-        value = attributes[name] || defn[:default]
+        value = attributes.fetch(name) { defn[:default] }
         memo[name] = value unless value.nil?
       }
 


### PR DESCRIPTION
The truthy check here means it fails for falsy values, so something like:

```
sortable: false
```

... would never make it through to the AST.