### PR TITLE
Add initial attributes url option to upload fields.

### DIFF
--- a/lib/formalist/elements/standard/multi_upload_field.rb
+++ b/lib/formalist/elements/standard/multi_upload_field.rb
@@ -5,6 +5,7 @@ require "formalist/types"
 module Formalist
   class Elements
     class MultiUploadField < Field
+      attribute :initial_attributes_url, Types::String
       attribute :sortable, Types::Bool
       attribute :max_file_size_message, Types::String
       attribute :max_file_size, Types::String

--- a/lib/formalist/elements/standard/upload_field.rb
+++ b/lib/formalist/elements/standard/upload_field.rb
@@ -5,6 +5,7 @@ require "formalist/types"
 module Formalist
   class Elements
     class UploadField < Field
+      attribute :initial_attributes_url, Types::String
       attribute :presign_url, Types::String
       attribute :presign_options, Types::Hash
       attribute :render_uploaded_as, Types::String


### PR DESCRIPTION
This adds support for an `initial_attributes_url` option on upload fields.